### PR TITLE
Add unified AC modes

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -154,7 +154,8 @@
                   "HEATING"
                 ]
               }
-            ]
+            ],
+            "default": "COOLING"
           },
           "ac_swing_mode": {
             "title": "Swing Mode (vertical or horizontal)",
@@ -218,7 +219,7 @@
           "ac_energy_save": {
             "title": "Energy save as switch",
             "type": "boolean",
-            "default": true
+            "default": false
           },
           "ac_air_clean": {
             "title": "Air purify as switch",

--- a/src/characteristics/ACMode.ts
+++ b/src/characteristics/ACMode.ts
@@ -1,0 +1,19 @@
+import type { WithUUID, Characteristic } from 'homebridge';
+import { Formats, Perms } from 'homebridge';
+
+export default function ACMode(
+  DefaultCharacteristic: typeof Characteristic,
+): WithUUID<new () => Characteristic> {
+  return class ACMode extends DefaultCharacteristic {
+    static readonly UUID = '4E9EF1BB-BC8A-4F54-A659-5C26E1845B0B';
+
+    constructor() {
+      super('AC Mode', ACMode.UUID, {
+        format: Formats.UINT8,
+        minValue: 0,
+        maxValue: 3,
+        perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE, Perms.NOTIFY],
+      });
+    }
+  };
+}

--- a/src/characteristics/index.ts
+++ b/src/characteristics/index.ts
@@ -4,15 +4,18 @@ import type {
 } from 'homebridge';
 
 import TotalConsumption from './TotalConsumption';
+import ACMode from './ACMode';
 
 export default function characteristic(
   Characteristic: typeof CharacteristicType,
 ): Record<
-  | 'TotalConsumption',
+  | 'TotalConsumption'
+  | 'ACMode',
   WithUUID<new () => CharacteristicType>
 > {
 
   return {
     TotalConsumption: TotalConsumption(Characteristic),
+    ACMode: ACMode(Characteristic),
   };
 }


### PR DESCRIPTION
## Summary
- add custom ACMode characteristic
- default AC accessory config is now cooling-only
- expose ACMode on the heater/cooler service for FAN and DRY
- tidy update logic for op modes
- support ENERGY_SAVE AC mode

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: rimraf not found)*
- `npx tsc -p tsconfig.json` *(fails: TypeScript lib not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0978bcfc8324b5ad6744aa3a6ea5