### PR TITLE
Improve npm package configuration

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -135,3 +135,4 @@ dist
 .pnp.*
 
 .idea
+sample

--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
     "node": "^18.20.4 || ^20.15.1 || ^22"
   },
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "config.schema.json",
+    "homebridge-ui"
+  ],
   "bin": {
     "thinq": "./dist/cli.js"
   },
@@ -26,6 +32,7 @@
     "lint": "eslint src/**.ts --max-warnings=0",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run lint && npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- mark built files as published output with a `files` array
- expose TypeScript declarations via `types`
- ensure build runs on install via `prepare` script
- omit sample data from the npm package

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685b0f67ef2883248799e12f33ab013b